### PR TITLE
Fix KickCommand permission rank to Helper

### DIFF
--- a/src/com/wheezygold/happybot/commands/KickCommand.java
+++ b/src/com/wheezygold/happybot/commands/KickCommand.java
@@ -17,7 +17,7 @@ public class KickCommand extends Command {
 
     @Override
     protected void execute(CommandEvent e) {
-        if (C.hasRole(e.getGuild(), e.getMember(), Roles.MODERATOR)) {
+        if (C.hasRole(e.getGuild(), e.getMember(), Roles.HELPER)) {
             if (e.getMessage().getMentionedUsers().size() == 1) {
                 String bname = C.getMemberEvent(e).getUser().getName();
                 String bdescrim = C.getMemberEvent(e).getUser().getDiscriminator();
@@ -27,7 +27,7 @@ public class KickCommand extends Command {
                 e.replyError("**Correct Usage:** ^" + name + " " + arguments);
             }
         } else {
-            e.replyError(C.permMsg(Roles.MODERATOR));
+            e.replyError(C.permMsg(Roles.HELPER));
         }
     }
 }


### PR DESCRIPTION
Helpers can manually kick people from the server but they do not have permission to use this command to kick people. This pull request fixes the rank required (Helper, previously Moderator) to kick someone from the server.