### PR TITLE
Added a missing space character when creating a new gamble account.

### DIFF
--- a/src/main/java/io/github/jroy/happybot/commands/money/MoneyCommand.java
+++ b/src/main/java/io/github/jroy/happybot/commands/money/MoneyCommand.java
@@ -149,7 +149,7 @@ public class MoneyCommand extends CommandBase {
         if (!sqlManager.isActiveUser(e.getMember().getUser().getId())) {
           sqlManager.newUser(e.getMember().getUser().getId());
           e.replySuccess("Your gamble account has been made!\n" +
-              "You should try " + C.code("^money claim") + ":wink:");
+              "You should try " + C.code("^money claim") + " :wink:");
         } else {
           e.replyError("You already have an account!");
         }


### PR DESCRIPTION
Found a small typo in the money command that I wanted to fix. It looks bad on the Discord client when an emoji is directly next to text.